### PR TITLE
feat(humanbound-test): coffee-message exit after dispatch on /run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and each plugin adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- **humanbound-test:** `/humanbound-test:run` no longer polls the experiment
+  and renders findings inline. After dispatch it prints a randomly-chosen
+  "grab a coffee" message (sourced verbatim from the `hb connect` exit
+  message in `humanbound-cli`), the experiment ID, and a one-line watch
+  hint pointing at `/humanbound-test:resume <id>`, then exits. Results are
+  delivered by email; in-band polling + findings render is now reached
+  only via `/humanbound-test:resume <id>` (the polling logic moved into a
+  dedicated "Resume path" section in `dispatching-hb-tests/SKILL.md` — no
+  behavior change for resume itself).
+
 ## [humanbound-test 0.1.0] — 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
 
 | Plugin | Purpose | Status |
 |---|---|---|
-| [`humanbound-test`](plugins/humanbound-test/) | Run adversarial / security tests against a local AI agent end-to-end — currently FastAPI-only, exposes via ngrok, dispatches via the Humanbound MCP, renders findings. | `v0.1.0` |
+| [`humanbound-test`](plugins/humanbound-test/) | Run adversarial / security tests against a local AI agent end-to-end — currently FastAPI-only, exposes via ngrok, dispatches via the Humanbound MCP, results delivered by email (or `/humanbound-test:resume <id>` to watch in-band). | `v0.1.0` |
 
 ## Install in Claude Code
 

--- a/plugins/humanbound-test/.claude-plugin/plugin.json
+++ b/plugins/humanbound-test/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "humanbound-test",
   "version": "0.1.0",
-  "description": "Run adversarial / security tests against your local AI agent. Detects your FastAPI server, exposes it via ngrok, you author bot-config.json with your endpoints / auth / payload, the plugin dispatches via the humanbound MCP and renders findings with severity counts and posture score.",
+  "description": "Run adversarial / security tests against your local AI agent. Detects your FastAPI server, exposes it via ngrok, you author bot-config.json with your endpoints / auth / payload, the plugin dispatches via the humanbound MCP — results delivered by email (or run /humanbound-test:resume <id> to watch the polling loop and findings inline).",
   "author": { "name": "humanbound" },
   "homepage": "https://github.com/humanbound/plugins",
   "repository": "https://github.com/humanbound/plugins",

--- a/plugins/humanbound-test/.cursor-plugin/plugin.json
+++ b/plugins/humanbound-test/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "humanbound-test",
   "displayName": "Humanbound Test",
   "version": "0.1.0",
-  "description": "Adversarial / security testing for local AI agents — auto-detects the FastAPI server, you author bot-config.json with endpoints / auth / payload, exposes via ngrok, dispatches via the Humanbound MCP, renders findings.",
+  "description": "Adversarial / security testing for local AI agents — auto-detects the FastAPI server, you author bot-config.json with endpoints / auth / payload, exposes via ngrok, dispatches via the Humanbound MCP. Results delivered by email; run /humanbound-test:resume <id> to watch in-band.",
   "author": { "name": "humanbound" },
   "homepage": "https://github.com/humanbound/plugins",
   "repository": "https://github.com/humanbound/plugins",

--- a/plugins/humanbound-test/README.md
+++ b/plugins/humanbound-test/README.md
@@ -5,7 +5,8 @@
   <br/>
   Auto-detects your FastAPI server, exposes it via ngrok, you fill in
   <code>bot-config.json</code>, the plugin dispatches via the
-  <code>humanbound</code> MCP and renders findings.
+  <code>humanbound</code> MCP — results land in your inbox by email
+  (or run <code>/humanbound-test:resume &lt;id&gt;</code> to watch in-band).
 </p>
 
 <p align="center">

--- a/plugins/humanbound-test/skills/dispatching-hb-tests/SKILL.md
+++ b/plugins/humanbound-test/skills/dispatching-hb-tests/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dispatching-hb-tests
-description: Internal phase skill for humanbound-test. Picks/creates the humanbound project, reads the user-authored ClientBotConfiguration from bot-config.json, dispatches the test via `hb_connect` or `hb_run_test`, polls until terminal, and renders findings. Drives Step 6 of the orchestrator (the "Run test" phase: project picker + summary + confirm + dispatch + poll + render). Do NOT trigger on user phrasing.
+description: Internal phase skill for humanbound-test. Picks/creates the humanbound project, reads the user-authored ClientBotConfiguration from bot-config.json, dispatches the test via `hb_connect` or `hb_run_test`, then exits with a "grab a coffee" message and watch hint — results are delivered by email. Drives Step 6 of the orchestrator (the "Run test" phase: project picker + summary + confirm + dispatch + exit). On `intent=resume <id>`, polls until terminal and renders findings inline. Do NOT trigger on user phrasing.
 ---
 
 # Dispatching humanbound tests
 
-Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers test-run config (depth, fail-on, etc.), dispatches with the bot-config that was prepared in Step 5, polls, renders findings. MCP authentication is verified in Step 1 of the orchestrator; by the time this skill runs we can trust hb_whoami returns authenticated:true.
+Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers test-run config (depth, fail-on, etc.), dispatches with the bot-config that was prepared in Step 5, then exits with a watch hint — results are delivered by email. Polling + findings render lives under the "Resume path" section below and is reached only from `intent=resume <id>`. MCP authentication is verified in Step 1 of the orchestrator; by the time this skill runs we can trust hb_whoami returns authenticated:true.
 
 ## Cross-cutting rules
 
@@ -15,7 +15,7 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
 4. **Detected values are surfaced as plain text, never as a prompt.**
 5. **`AskUserQuestion` always exposes "Other" automatically.**
 6. **Surface every MCP tool's error verbatim. Stop on failure — never retry the same call unchanged.**
-7. **Polling discipline:** wait ≥15s between `hb_get_experiment_status` calls. Stop when status ∈ {succeeded, failed, terminated}. Cap at 60 iterations (~15 min).
+7. **No polling on the run path.** `intent=run` exits after dispatch with a coffee message + watch hint — do NOT call `hb_get_experiment_status`, `hb_list_findings`, or `hb_get_posture` from the run flow. Polling discipline applies on the resume path only (see "Resume path" section): wait ≥15s between `hb_get_experiment_status` calls, stop when status ∈ {succeeded, failed, terminated}, cap at 60 iterations (~15 min).
 8. **Do not tear down the tunnel automatically.** Always remind the user to run `/humanbound-test:stop` when done.
 
 ---
@@ -173,7 +173,57 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
 
 11. Print: "  ✓ experiment_id: <id>"
 
-12. Polling loop (max 60 iterations, 15s between):
+12. Exit with watch hint — DO NOT POLL.
+
+    Pick one line at random from the list below. Lines are sourced verbatim from
+    the CLI's `hb connect` / `hb test` exit message — keep the emoji prefix and
+    the em-dash (U+2014). Do NOT rewrite, translate, or strip the emoji.
+
+      "☕ Go grab a coffee — we've got it from here. Email incoming when done."
+      "🍺 Red team deployed — treat yourself to a beer, email coming soon."
+      "🌿 Our agents are on it — go touch grass, we'll email you the results."
+      "🥊 The bots are fighting — grab a snack and check your inbox later."
+      "🔓 Hacking in progress — no really, go do something fun. Email on the way."
+      "🚀 We're poking your agent now — go stretch, results hit your inbox shortly."
+      "🧘 Time for a break — we'll ping you by email once we're through."
+      "🎯 Sit back and relax — we'll email you when results are ready."
+
+    Then print the exit block. Single line per row (same vocabulary as Step 7),
+    middle-dot `·` (U+00B7) separator where multiple fields share a row:
+
+      ──────────────────────────────────────────────────────────────────
+        <chosen coffee line>
+
+        Experiment   <experiment_id>
+        Watch        /humanbound-test:resume <experiment_id>
+      ──────────────────────────────────────────────────────────────────
+
+    Hard rules for Step 12:
+      • Do NOT call `hb_get_experiment_status`, `hb_list_findings`, or
+        `hb_get_posture` here. Results are delivered by email; the user opts
+        in to in-band polling via `/humanbound-test:resume <id>`.
+      • Do NOT loop, sleep, or "just check once" — exit immediately after
+        printing the block.
+      • The experiment block in state.json keeps `status="running"`
+        (written by Step 10). It updates to a terminal status only when
+        `/humanbound-test:resume <id>` is run.
+
+13. Always remind:
+     "  ⚠ Tunnel is still running at <public-url>"
+     "    Run /humanbound-test:stop to tear it down."
+```
+
+---
+
+## Resume path — polling + findings render
+
+Entered from the orchestrator's `intent=resume <id>` (running-adversarial-tests).
+Steps 1–11 of the run flow are skipped — the experiment already exists; we just
+observe it and render results inline. This section owns the polling discipline
+called out in cross-cutting rule #7.
+
+```
+1. Polling loop (max 60 iterations, 15s between):
      a. Call hb_get_experiment_status(experiment_id).
      b. AFTER each call returns, ALWAYS print one readable line directly below
         the JSON receipt — never skip this, even on the very first iteration:
@@ -193,7 +243,7 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
             are preserved.)
           • Break the polling loop.
 
-13. If still running at iteration 60:
+2. If still running at iteration 60:
      Print: "  ⚠ still running — experiment_id=<id>. Re-run /humanbound-test:resume <id>."
      Persist {experiment.status="running"} via:
        PROJECT="<project>" bash -c "source $LIB/paths.sh; source $LIB/pidfile.sh; \
@@ -201,13 +251,14 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
      This too is a merge — preserves tunnel state and the rest of the experiment block.
      Stop.
 
-14. Render findings (see reference/findings-renderer.md):
+3. Render findings (see reference/findings-renderer.md):
      a. Call hb_get_experiment_logs(experiment_id). Print run summary.
      b. Call hb_list_findings(experiment_id). Print:
           - severity counts: "by severity:    critical=<n>   high=<n>   medium=<n>   low=<n>"
           - top 5 with bullets: "[<SEV>] <title>"
      c. Call hb_get_posture(project_id). Print "posture score: <s> / 100".
-     d. Fail-on verdict (uses the `fail_on` value chosen in Step 4):
+     d. Fail-on verdict (uses the `fail_on` value chosen at original dispatch
+        — read from state.json if not in scope):
           if any finding.severity >= fail_on:
             print "✗ FAIL: <count> finding(s) at severity >= <fail_on>"
             verdict = "FAIL"
@@ -231,7 +282,7 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
         preserved. Single-quote the JSON arg to avoid shell-escaping the
         inner double-quotes.
 
-15. Always remind:
+4. Always remind:
      "  ⚠ Tunnel is still running at <public-url>"
      "    Run /humanbound-test:stop to tear it down."
 ```
@@ -241,4 +292,4 @@ Step 6 of the orchestrator — the "Run test" phase. Picks the project, gathers 
 ## See also
 
 - `reference/required-data.md` — full ClientBotConfiguration / Project / Experiment schema.
-- `reference/findings-renderer.md` — exact terminal layout for the findings block.
+- `reference/findings-renderer.md` — exact terminal layout for the findings block (rendered on the resume path).

--- a/plugins/humanbound-test/skills/running-adversarial-tests/SKILL.md
+++ b/plugins/humanbound-test/skills/running-adversarial-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: running-adversarial-tests
-description: MUST USE for ANY request to run an adversarial / security / pentest test against a local AI agent. Triggers on phrases like "run an adversarial test on my local agent", "run an adversarial test", "pentest my AI", "security test for my agent", "run owasp_agentic on my assistant", "test my chatbot for jailbreaks", "run a humanbound test", "run hb test on this", "test my agent". Drives the full end-to-end flow — verify humanbound MCP, detect server, discover endpoints, expose via ngrok, dispatch via humanbound MCP, poll, and render findings.
+description: MUST USE for ANY request to run an adversarial / security / pentest test against a local AI agent. Triggers on phrases like "run an adversarial test on my local agent", "run an adversarial test", "pentest my AI", "security test for my agent", "run owasp_agentic on my assistant", "test my chatbot for jailbreaks", "run a humanbound test", "run hb test on this", "test my agent". Drives the full end-to-end flow — verify humanbound MCP, detect server, discover endpoints, expose via ngrok, dispatch via humanbound MCP, then exit with a "grab a coffee" message (results land in the user's inbox by email; `/humanbound-test:resume <id>` is the opt-in in-band polling + findings render).
 ---
 
 # Running an adversarial test against a local agent
@@ -235,9 +235,11 @@ The skill is invoked from the slash commands with `intent=<verb>`:
 
 7. Step 6/6 — Run test:
    Invoke `dispatching-hb-tests`. It owns: project picker, test config gathering,
-   summary block, confirm prompt, dispatch (hb_connect / hb_run_test), polling
-   loop, and findings render. The skill prints "▸ Step 6/6  Running test" and
-   reads bot-config.json directly from `<project>/.humanbound/test/bot-config.json`.
+   summary block, confirm prompt, dispatch (hb_connect / hb_run_test), and the
+   coffee-message exit block (no in-band polling — results delivered by email;
+   the user opts into in-band polling via `/humanbound-test:resume <id>`). The
+   skill prints "▸ Step 6/6  Running test" and reads bot-config.json directly
+   from `<project>/.humanbound/test/bot-config.json`.
 
 8. Final reminder line about `/humanbound-test:stop` — printed by `dispatching-hb-tests`.
 ```
@@ -247,8 +249,10 @@ The skill is invoked from the slash commands with `intent=<verb>`:
 ```
 1. Print: "▸ Resuming experiment <id>"
 2. Read state.json. If experiment.id != <id>: warn but proceed.
-3. Skip to Step 6/6 of `dispatching-hb-tests` polling loop.
-4. Render findings.
+3. Invoke `dispatching-hb-tests` — "Resume path — polling + findings render"
+   section. Polls hb_get_experiment_status, renders findings on terminal status,
+   updates state.json with the summary digest. (Steps 1–11 of the run flow are
+   skipped — the experiment already exists.)
 ```
 
 ## intent=setup


### PR DESCRIPTION
<!-- Thanks for contributing to humanbound/plugins!
     Security issues must NOT be opened as PRs — see SECURITY.md. -->

## Summary

<!-- What does this change do and why? Which plugin(s) does it touch? -->

Mirror the CLI's `hb connect` / `hb test` exit UX. After hb_run_test / hb_connect, the plugin now prints a randomly-chosen "grab a coffee" line (8 lines copied verbatim from humanbound_cli/commands/connect.py — keeps brand voice consistent), the experiment_id, and a one-line watch hint pointing at /humanbound-test:resume <id>. Polling + findings render no longer block the editor session for ~15 minutes; results land via email, and the user opts into in-band polling explicitly via :resume.

The polling + findings-render logic itself is unchanged — relocated from Step 6/6 of dispatching-hb-tests into a dedicated "Resume path" section in the same skill. /humanbound-test:resume <id> now points there explicitly. Cross-cutting rule #7 reworded ("no polling on run path; resume only") to make the boundary load-bearing for future readers.

state.json semantics:
  - Step 10 (write_experiment with status="running") still fires.
  - update_experiment_status to terminal + write_experiment_summary only happen on the :resume path. /humanbound-test:status will show status=running until the user resumes — same merge-safe writers, same digest shape.

Tunnel survives the test as before (rule #8 unchanged); final reminder to run /humanbound-test:stop still prints.

Touched files:
  - plugins/humanbound-test/skills/dispatching-hb-tests/SKILL.md
  - plugins/humanbound-test/skills/running-adversarial-tests/SKILL.md
  - plugins/humanbound-test/README.md
  - plugins/humanbound-test/.claude-plugin/plugin.json
  - plugins/humanbound-test/.cursor-plugin/plugin.json
  - README.md (umbrella plugin table)
  - CHANGELOG.md (Unreleased / Changed)

Manual test plan (slash flows are not auto-tested per CONTRIBUTING.md):
  1. /humanbound-test:run end-to-end → confirm dispatch prints experiment_id + a random coffee line + the :resume watch hint + "Tunnel is still running" reminder, and NO hb_get_experiment_status calls fire after dispatch.
  2. /humanbound-test:resume <id> → confirm polling loop + findings render + state.json summary digest still work as before.
  3. /humanbound-test:status during in-flight run → confirms it shows "status running" with no last-run digest until :resume completes.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change (would alter existing slash-command behavior or config schema)
- [ ] New plugin
- [ ] Documentation only
- [ ] Build / tooling / CI

## Tested in

- [x] Claude Code (version: 2.1.84)
- [x] Cursor (version: 2026.05.09-0afadcc)

## Checklist

- [x] Plugin tests pass (`./tests/run-tests.sh` inside the affected plugin)
- [x] Interactive flow verified manually in **both** Claude Code and Cursor
- [x] `CHANGELOG.md` updated under `[Unreleased]` with plugin name prefix
- [x] [CLA](https://github.com/humanbound/plugins/blob/main/CLA.md) signed (the CLAAssistant bot will prompt you on first PR)

## Linked issue(s)

<!-- Fixes #123 / closes #456 -->
