### PR TITLE
docs: replace the dead Discord invite

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,7 +7,7 @@ contact_links:
     url: https://github.com/humanbound/plugins/discussions
     about: Use Discussions for questions, ideas, and show-and-tell.
   - name: Discord community
-    url: https://discord.gg/gQyXjVBF
+    url: https://discord.gg/QFTD6tr9zu
     about: Chat with the community and the maintainers.
   - name: Documentation
     url: https://docs.humanbound.ai/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and each plugin adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - `CONTRIBUTING.md` gains an explicit third-party license policy: vendored
   code must be permissively licensed (Apache-2.0/MIT/BSD/ISC); GPL, AGPL,
   SSPL, and BSL code cannot be accepted.
+- **Discord links now point at the `#start-here` invite** (repo-wide, #7).
+  Every Discord link in the repo used `discord.gg/gQyXjVBF`, which no longer
+  resolves. `README.md`, `CONTRIBUTING.md`, the new-issue chooser, and the
+  `humanbound-test` plugin README now use `discord.gg/QFTD6tr9zu`, the live
+  invite www.humanbound.ai links to.
 
 ### Added
 - `NOTICE` file per Apache-2.0 section 4(d).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ repo itself is not versioned.
 
 ## Community
 
-- **Discord** — [discord.gg/gQyXjVBF](https://discord.gg/gQyXjVBF)
+- **Discord** — [discord.gg/QFTD6tr9zu](https://discord.gg/QFTD6tr9zu)
 - **Discussions** — on the GitHub repo
 - **Docs** — [docs.humanbound.ai](https://docs.humanbound.ai)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
   <img src="https://img.shields.io/badge/status-preview-FD9506?style=flat-square" alt="Status: preview"/>
   <a href="https://github.com/humanbound/plugins/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/humanbound/plugins/ci.yml?style=flat-square&color=FD9506" alt="CI"/></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-FD9506?style=flat-square" alt="License"/></a>
-  <a href="https://discord.gg/gQyXjVBF"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
+  <a href="https://discord.gg/QFTD6tr9zu"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
   <a href="https://docs.humanbound.ai/"><img src="https://img.shields.io/badge/docs-humanbound.ai-FD9506?style=flat-square" alt="Docs"/></a>
 </p>
 
@@ -100,7 +100,7 @@ dev loop, plugin layout conventions, and the DCO sign-off requirement (see
 - 🐛 [Report a bug](https://github.com/humanbound/plugins/issues/new/choose)
 - 💡 [Request a feature](https://github.com/humanbound/plugins/issues/new/choose)
 - 🔒 [Report a security issue](./SECURITY.md) — **not via public Issues**
-- 💬 [Join Discord](https://discord.gg/gQyXjVBF)
+- 💬 [Join Discord](https://discord.gg/QFTD6tr9zu)
 
 ## License
 

--- a/plugins/humanbound-test/README.md
+++ b/plugins/humanbound-test/README.md
@@ -19,7 +19,7 @@
 <p align="center">
   <img src="https://img.shields.io/badge/status-preview-FD9506?style=flat-square" alt="Status: preview"/>
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-FD9506?style=flat-square" alt="License"/></a>
-  <a href="https://discord.gg/gQyXjVBF"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
+  <a href="https://discord.gg/QFTD6tr9zu"><img src="https://img.shields.io/badge/discord-community-FD9506?style=flat-square" alt="Discord"/></a>
   <a href="https://docs.humanbound.ai/getting-started/agent-config/"><img src="https://img.shields.io/badge/docs-humanbound.ai-FD9506?style=flat-square" alt="Docs"/></a>
 </p>
 


### PR DESCRIPTION
## Summary

All five Discord links in this repo used `gQyXjVBF`, which the Discord API reports as "Unknown Invite". They now use `https://discord.gg/QFTD6tr9zu`, the live invite www.humanbound.ai links to, which opens in `#start-here`.

Covers `README.md`, `CONTRIBUTING.md`, the new-issue chooser, and the `humanbound-test` plugin README.

## Type of change

- [x] Documentation only

## Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] All commits are signed off (`git commit -s`)

No plugin behaviour changes, so the plugin test suite and the Claude Code and Cursor interactive flows are untouched by this.

## Linked issue(s)

Closes #7

## Companion PRs

The same change in the other four repos:

- humanbound/.github#2
- humanbound/humanbound#133
- humanbound/humanbound-firewall#20
- humanbound/actions#10

Cross-repo context is in humanbound/humanbound#132.
