### PR TITLE
docs(changelog): log the Apache-2.0 license restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and each plugin adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 - `CONTRIBUTING.md` gains an explicit third-party license policy: vendored
   code must be permissively licensed (Apache-2.0/MIT/BSD/ISC); GPL, AGPL,
   SSPL, and BSL code cannot be accepted.
+- `LICENSE` restored to the verbatim Apache-2.0 text (repo-wide). Sections 6
+  and 9 had diverged from the canonical wording and the appendix was
+  missing; the file now matches apache.org/licenses/LICENSE-2.0 exactly,
+  apart from the appendix copyright line. The license grant is unchanged —
+  the repository was and remains Apache-2.0 — but GitHub now detects the
+  license, where it previously reported the repository as "Other".
 
 ### Added
 - `NOTICE` file per Apache-2.0 section 4(d).


### PR DESCRIPTION
## Summary

Follow-up to #9, which restored `LICENSE` to the verbatim Apache-2.0 text but merged without a `CHANGELOG.md` entry.

This repo does log repo-wide governance changes — `[Unreleased]` already carries the CLA-to-DCO switch and the `NOTICE` addition from #4, both unprefixed since they aren't plugin-scoped. The license restore belongs beside them, otherwise the section reads as incomplete when the next release notes are written.

Changelog-only. No plugin, workflow, or license file is touched.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (would alter existing slash-command behavior or config schema)
- [ ] New plugin
- [x] Documentation only
- [ ] Build / tooling / CI

## Tested in

- [ ] Claude Code (version: _____) — n/a, no plugin code or manifest changed
- [ ] Cursor (version: _____) — n/a, same

## Checklist

- [ ] Plugin tests pass (`./tests/run-tests.sh` inside the affected plugin) — n/a, no plugin affected; nothing under `plugins/` is touched
- [ ] Interactive flow verified manually in **both** Claude Code and Cursor — n/a, no interactive flow changed
- [x] `CHANGELOG.md` updated under `[Unreleased]` with plugin name prefix — this PR is that entry; logged unprefixed under `### Changed`, matching the other repo-wide entries
- [x] All commits are signed off (`git commit -s`) — see [DCO.md](https://github.com/humanbound/plugins/blob/main/DCO.md)

## Linked issue(s)

<!-- follow-up to #9 -->
